### PR TITLE
Update Quran.com API link

### DIFF
--- a/README-AR.md
+++ b/README-AR.md
@@ -324,7 +324,7 @@ QT_MEDIA_BACKEND=ffmpeg ./quran-companion
 تم استخدام المشاريع/المواقع التالية في تطوير البرنامج:
 
 - [Ayat](https://quran.ksu.edu.sa/index.php)
-- [Quran.com API](https://quran.api-docs.io/)
+- [Quran.com API](https://api-docs.quran.com/)
 - [Every Ayah recitations](https://everyayah.com/recitations_ayat.html)
 - [Mosshaf](https://mosshaf.com/)
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ To contribute in translating the application, start by:
 The following projects/services were used in development:
 
 - [Ayat](https://quran.ksu.edu.sa/index.php)
-- [Quran.com API](https://quran.api-docs.io/)
+- [Quran.com API](https://api-docs.quran.com/)
 - [Every Ayah recitations](https://everyayah.com/recitations_ayat.html)
 - [Mosshaf](https://mosshaf.com/)
 


### PR DESCRIPTION
This pull request updates the link to the Quran.com API in the Credits section of the documentation. The previous link (https://quran.api-docs.io/) was outdated, and I have replaced it with the current link (https://api-docs.quran.com/).
