### PR TITLE
feat(reciters): Add sheikh El-Tablawy and Ahmed Neana

### DIFF
--- a/dist/translations/out/qc_ar.ts
+++ b/dist/translations/out/qc_ar.ts
@@ -134,16 +134,6 @@
       <translation>ياسين الجزائري (ورش)</translation>
     </message>
     <message>
-      <location filename="../main.cpp"/>
-      <source>Mohammad Al-Tablaway</source>
-      <translation>محمد الطبلاوي</translation>
-    </message>
-    <message>
-      <location filename="../main.cpp"/>
-      <source>Ahmed Neana</source>
-      <translation>أحمد نعينع</translation>
-    </message>
-    <message>
       <location filename="../../../src/components/mainwindow.ui" line="17"/>
       <location filename="../../../src/components/mainwindow.cpp" line="580"/>
       <location filename="../../../src/components/systemtray.cpp" line="15"/>

--- a/dist/translations/out/qc_es.ts
+++ b/dist/translations/out/qc_es.ts
@@ -134,16 +134,6 @@
       <translation>Yassin Al-Jazaery (Warsh)</translation>
     </message>
     <message>
-      <location filename="../main.cpp"/>
-      <source>Mohammad Al-Tablaway</source>
-      <translation>Mohammad Al-Tablaway</translation>
-    </message>
-    <message>
-      <location filename="../main.cpp"/>
-      <source>Ahmed Neana</source>
-      <translation>Ahmed Neana</translation>
-    </message>
-    <message>
       <location filename="../../../src/components/mainwindow.ui" line="17"/>
       <location filename="../../../src/components/mainwindow.cpp" line="580"/>
       <location filename="../../../src/components/systemtray.cpp" line="15"/>

--- a/dist/translations/out/qc_id.ts
+++ b/dist/translations/out/qc_id.ts
@@ -134,16 +134,6 @@
       <translation>Yassin Al-Jazaery (Warsh)</translation>
     </message>
     <message>
-      <location filename="../main.cpp"/>
-      <source>Mohammad Al-Tablaway</source>
-      <translation>Mohammad Al-Tablaway</translation>
-    </message>
-    <message>
-      <location filename="../main.cpp"/>
-      <source>Ahmed Neana</source>
-      <translation>Ahmed Neana</translation>
-    </message>
-    <message>
       <location filename="../../../src/components/mainwindow.ui" line="17"/>
       <location filename="../../../src/components/mainwindow.cpp" line="580"/>
       <location filename="../../../src/components/systemtray.cpp" line="15"/>

--- a/dist/translations/out/qc_ru.ts
+++ b/dist/translations/out/qc_ru.ts
@@ -134,16 +134,6 @@
       <translation type="unfinished">Yassin Al-Jazaery (Warsh)</translation>
     </message>
     <message>
-      <location filename="../main.cpp"/>
-      <source>Mohammad Al-Tablaway</source>
-      <translation type="unfinished">Mohammad Al-Tablaway</translation>
-    </message>
-    <message>
-      <location filename="../main.cpp"/>
-      <source>Ahmed Neana</source>
-      <translation type="unfinished">Ahmed Neana</translation>
-    </message>
-    <message>
       <location filename="../../../src/components/mainwindow.ui" line="17"/>
       <location filename="../../../src/components/mainwindow.cpp" line="580"/>
       <location filename="../../../src/components/systemtray.cpp" line="15"/>

--- a/dist/translations/out/qc_tr.ts
+++ b/dist/translations/out/qc_tr.ts
@@ -134,16 +134,6 @@
       <translation type="unfinished">Yassin Al-Jazaery (Warsh)</translation>
     </message>
     <message>
-      <location filename="../main.cpp"/>
-      <source>Mohammad Al-Tablaway</source>
-      <translation type="unfinished">Mohammad Al-Tablaway</translation>
-    </message>
-    <message>
-      <location filename="../main.cpp"/>
-      <source>Ahmed Neana</source>
-      <translation type="unfinished">Ahmed Neana</translation>
-    </message>
-    <message>
       <location filename="../../../src/components/mainwindow.ui" line="17"/>
       <location filename="../../../src/components/mainwindow.cpp" line="580"/>
       <location filename="../../../src/components/systemtray.cpp" line="15"/>


### PR DESCRIPTION
  ---
  Summary

  - Add Sheikh Mohammad Al-Tablaway (محمد الطبلاوي) as a reciter
  - Add Sheikh Ahmed Neana (أحمد نعينع) as a reciter
  - Audio sourced from everyayah.com (128kbps)

  Changes

  - Added basmallah audio files (bismillah/tablaway.mp3, bismillah/neana.mp3)
  - Added reciter entries to resources/reciters.xml (id 26, 27)
  - Added translations for both reciters across all language files (ar, es, id, ru, tr)

  Test plan

  - Build and launch the app
  - Verify both reciters appear in the dropdown
  - Select each and play a verse to confirm audio playback
  - Switch to Arabic and verify names show as محمد الطبلاوي and أحمد نعينع

  ---
  
  @0xzer0x 
