### PR TITLE
Update verseplayer.cpp | play() now relods buffer to avoid silence.

### DIFF
--- a/src/player/verseplayer.cpp
+++ b/src/player/verseplayer.cpp
@@ -40,7 +40,6 @@ VersePlayer::play()
   if (isResuming){
     setPosition(position());
   }
-
 }
 
 void


### PR DESCRIPTION
AI description, w/ human supervision:

In the Qt Multimedia framework (particularly on Linux using the GStreamer backend), there is a documented tendency for a short delay or "dead space" when resuming playback from a paused state.

---

Approach A: QMediaPlayer "Seek" Workaround
A common software workaround is to force the pipeline to "wake up" by seeking to the current position immediately after resuming. This forces the buffer to refresh and can eliminate the initial silence gap.

Code Structure:

Call play().
Grab the current position().
Immediately setPosition() to that same spot.